### PR TITLE
Downgrade gradle version to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,6 @@ allprojects {
 }
 
 wrapper {
-    gradleVersion = '5.5.1'
+    gradleVersion = '5.1.1'
     distributionUrl = distributionUrl.replace("bin", "all")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/parser/src/main/kotlin/com/undabot/izzy/models/Error.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/models/Error.kt
@@ -7,5 +7,6 @@ data class Error(
     var title: String? = null,
     var detail: String? = null,
     var source: Source? = null,
-    var meta: Map<String, Any?>? = null
+    var meta: Map<String, Any?>? = null,
+    var customProperties: Map<String, Any?>? = null
 )

--- a/parser/src/main/kotlin/com/undabot/izzy/models/RelationshipFields.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/models/RelationshipFields.kt
@@ -5,7 +5,7 @@ import com.undabot.izzy.parser.JsonElements
 import java.lang.reflect.Field
 
 class RelationshipFields {
-    private val map = LinkedHashMap<ResourceID, Field>()
+    private val map = mutableListOf<Pair<ResourceID, Field>>()
 
     fun addToPool(relationshipData: JsonElements, relationshipField: Field) {
         if (relationshipData.isArray())
@@ -48,11 +48,11 @@ class RelationshipFields {
                 }
     }
 
-    fun add(resourceUnique: ResourceID, field: Field) = map.put(resourceUnique, field)
+    fun add(resourceUnique: ResourceID, field: Field) = map.add(resourceUnique to field)
 
     fun hasRelationships() = map.isNotEmpty()
 
     fun get() = map
 
-    fun fieldOrNull(resourceUnique: ResourceID) = map[resourceUnique]!!
+    fun fieldOrNull(resourceUnique: ResourceID) = map.find { it.first == resourceUnique }
 }

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeError.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeError.kt
@@ -4,18 +4,30 @@ import com.undabot.izzy.models.Error
 
 class DeserializeError(
     private val deserializeSource: DeserializeSource = DeserializeSource(),
-    private val deserializeMeta: DeserializeMeta = DeserializeMeta()
+    private val deserializeMeta: DeserializeMeta = DeserializeMeta(),
+    private val deserializeErrorCustomProperties: DeserializeErrorCustomProperties = DeserializeErrorCustomProperties()
 ) {
+
+    private val idKey = "id"
+    private val statusKey = "status"
+    private val codeKey = "code"
+    private val titleKey = "title"
+    private val detailKey = "detail"
+    private val sourceKey = "source"
 
     fun from(errorElement: JsonElements): Error {
         return Error(
-                id = errorElement.stringFor("id"),
-                status = errorElement.stringFor("status"),
-                code = errorElement.stringFor("code"),
-                title = errorElement.stringFor("title"),
-                detail = errorElement.stringFor("detail"),
-                source = deserializeSource.from(errorElement.jsonElement("source")),
-                meta = deserializeMeta.from(errorElement)
+            id = errorElement.stringFor(idKey),
+            status = errorElement.stringFor(statusKey),
+            code = errorElement.stringFor(codeKey),
+            title = errorElement.stringFor(titleKey),
+            detail = errorElement.stringFor(detailKey),
+            source = deserializeSource.from(errorElement.jsonElement(sourceKey)),
+            meta = deserializeMeta.from(errorElement),
+            customProperties = deserializeErrorCustomProperties.from(
+                errorElement,
+                listOf(idKey, statusKey, codeKey, titleKey, detailKey, sourceKey, META)
+            )
         )
     }
 }

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeErrorCustomProperties.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeErrorCustomProperties.kt
@@ -1,0 +1,16 @@
+package com.undabot.izzy.parser
+
+class DeserializeErrorCustomProperties {
+
+    fun from(jsonElements: JsonElements, ignoreProperties: List<String>): Map<String, Any?>? {
+        val notIgnoredElements = jsonElements.asMap()?.toMutableMap()
+
+        notIgnoredElements?.let { elements ->
+            ignoreProperties.forEach {
+                elements.remove(it)
+            }
+        }
+
+        return if (notIgnoredElements.isNullOrEmpty()) null else notIgnoredElements
+    }
+}

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeMeta.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeMeta.kt
@@ -2,12 +2,25 @@ package com.undabot.izzy.parser
 
 class DeserializeMeta {
 
+    fun fromRoot(jsonElements: JsonElements): Map<String, Any?>? {
+        val root = jsonElements.asMap()
+
+        return when (hasMetaIn(root)) {
+            true -> root!![META] as Map<String, Any?>
+            false -> null
+        }
+    }
+
     fun from(jsonElements: JsonElements): Map<String, Any?>? =
-            when (hasMetaIn(jsonElements)) {
-                true -> jsonElements.jsonElement(META).asMap()
-                false -> null
+        when (hasMetaIn(jsonElements)) {
+            true -> {
+                jsonElements.jsonElement(META).asMap()
             }
+            false -> null
+        }
 
     private fun hasMetaIn(jsonElements: JsonElements) =
-            jsonElements.isObject() && jsonElements.hasNonNull(META)
+        jsonElements.isObject() && jsonElements.hasNonNull(META)
+
+    private fun hasMetaIn(meta: Map<String, *>?) = meta?.contains(META) ?: false
 }

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeRelationships.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeRelationships.kt
@@ -10,6 +10,8 @@ import com.undabot.izzy.models.RelationshipFields
 import com.undabot.izzy.models.Resource
 import com.undabot.izzy.models.ResourceID
 import com.undabot.izzy.typeFromResource
+import kotlin.reflect.KClass
+import kotlin.reflect.full.allSuperclasses
 
 class DeserializeRelationships(
     private val izzyJsonParser: IzzyJsonParser,
@@ -96,20 +98,36 @@ class DeserializeRelationships(
     ) {
         val id = ResourceID(resource.id!!, type)
         val relationshipFields = RelationshipFields().apply {
-            resource::class.java.annotatedWith(Relationship::class.java)
-                    .forEach { relationshipField ->
-                        val relationshipName = relationshipField.getAnnotation(Relationship::class.java).name
+            extractResourceRelationships(resource::class, relationshipsJsonObject, resource, pool)
 
-                        if (relationshipsJsonObject.has(relationshipName)) {
-                            val relationshipData = getRelationshipDataFrom(relationshipsJsonObject, relationshipName)
-                            relationshipField.isAccessible = true
-                            addToPool(relationshipData, relationshipField)
-                            putResourceRelationshipsToPool(resource, relationshipsJsonObject, pool)
-                        }
-                    }
+            val relationships = resource::class.allSuperclasses
+            relationships.forEach { kClass ->
+                extractResourceRelationships(kClass, relationshipsJsonObject, resource, pool)
+            }
         }
 
         pool.put(id, Resource(ClassInstance(resource::class.java, resource), relationshipFields))
+    }
+
+    private fun <T : IzzyResource> RelationshipFields.extractResourceRelationships(
+        kClass: KClass<*>,
+        relationshipsJsonObject: JsonElements,
+        resource: T,
+        pool: DataPool
+    ) {
+        kClass.java.annotatedWith(Relationship::class.java)
+            .forEach { relationshipField ->
+                val relationshipName =
+                    relationshipField.getAnnotation(Relationship::class.java).name
+
+                if (relationshipsJsonObject.has(relationshipName)) {
+                    val relationshipData =
+                        getRelationshipDataFrom(relationshipsJsonObject, relationshipName)
+                    relationshipField.isAccessible = true
+                    addToPool(relationshipData, relationshipField)
+                    putResourceRelationshipsToPool(resource, relationshipsJsonObject, pool)
+                }
+            }
     }
 
     private fun resourceWithoutRelationships(resId: ResourceID, classInstance: ClassInstance, pool: DataPool) {

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeRelationships.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/DeserializeRelationships.kt
@@ -12,6 +12,7 @@ import com.undabot.izzy.models.ResourceID
 import com.undabot.izzy.typeFromResource
 import kotlin.reflect.KClass
 import kotlin.reflect.full.allSuperclasses
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 
 class DeserializeRelationships(
     private val izzyJsonParser: IzzyJsonParser,
@@ -100,10 +101,12 @@ class DeserializeRelationships(
         val relationshipFields = RelationshipFields().apply {
             extractResourceRelationships(resource::class, relationshipsJsonObject, resource, pool)
 
-            val relationships = resource::class.allSuperclasses
-            relationships.forEach { kClass ->
-                extractResourceRelationships(kClass, relationshipsJsonObject, resource, pool)
-            }
+            try {
+                val relationships = resource::class.allSuperclasses
+                relationships.forEach { kClass ->
+                    extractResourceRelationships(kClass, relationshipsJsonObject, resource, pool)
+                }
+            } catch (e: KotlinReflectionInternalError) {}
         }
 
         pool.put(id, Resource(ClassInstance(resource::class.java, resource), relationshipFields))

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/Izzy.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/Izzy.kt
@@ -86,7 +86,7 @@ class Izzy(private val izzyJsonParser: IzzyJsonParser) {
 
     private fun linksFrom(jsonTree: JsonElements) = deserializeLinks.from(jsonTree)
 
-    private fun metaFrom(jsonTree: JsonElements) = deserializeMeta.from(jsonTree)
+    private fun metaFrom(jsonTree: JsonElements) = deserializeMeta.fromRoot(jsonTree)
 
     private fun validate(jsonTree: JsonElements) = validateJsonDocument.from(jsonTree)
 }

--- a/parser/src/main/kotlin/com/undabot/izzy/parser/RelationshipMatcher.kt
+++ b/parser/src/main/kotlin/com/undabot/izzy/parser/RelationshipMatcher.kt
@@ -37,9 +37,9 @@ class RelationshipMatcher {
         poolItem.value
                 .second
                 .get()
-                .filterNot { it.value.type.isCollection() }
+                .filterNot { it.second.type.isCollection() }
                 .forEach { resource ->
-                    resource.value.set(poolItem.value.first.instance, pool.resourceForId(resource.key)?.first?.instance)
+                    resource.second.set(poolItem.value.first.instance, pool.resourceForId(resource.first)?.first?.instance)
                 }
     }
 
@@ -81,7 +81,7 @@ class RelationshipMatcher {
         fromResource: MutableMap.MutableEntry<ResourceID, Resource>
     ): Map<ResourceID, Field> {
         return fromResource.value.second.get()
-                .filter { entry -> entry.value.type.isCollection() }
+                .filter { entry -> entry.second.type.isCollection() }.toMap()
     }
 
     private fun relationshipsFound(poolItem: MutableMap.MutableEntry<ResourceID, Resource>) =

--- a/parser/src/test/kotlin/com/undabot/izzy/AddResourceToPoolShould.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/AddResourceToPoolShould.kt
@@ -54,7 +54,7 @@ class AddResourceToPoolShould {
     }
 
     private fun `class of relationship from pool`() =
-            pool.resourceForId(ResourceID(testId, type))!!.second.fieldOrNull(ResourceID("10", "persons")).type
+            pool.resourceForId(ResourceID(testId, type))!!.second.fieldOrNull(ResourceID("10", "persons"))!!.second.type
 
     private fun `class from pool`() = pool.resourceForId(ResourceID(testId, type))!!.first.classData
 }

--- a/parser/src/test/kotlin/com/undabot/izzy/model/BasePerson.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/model/BasePerson.kt
@@ -1,0 +1,14 @@
+package com.undabot.izzy.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.undabot.izzy.annotations.Relationship
+import com.undabot.izzy.annotations.Type
+import com.undabot.izzy.models.IzzyResource
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Type("base_persons")
+open class BasePerson : IzzyResource() {
+
+    @Relationship("supervisor")
+    var supervisor: Person? = null
+}

--- a/parser/src/test/kotlin/com/undabot/izzy/model/Person.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/model/Person.kt
@@ -4,13 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.undabot.izzy.annotations.Relationship
 import com.undabot.izzy.annotations.Type
-import com.undabot.izzy.models.IzzyResource
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Type("persons")
 data class Person(
     @JsonProperty("name") var name: String? = null
-) : IzzyResource() {
+) : BasePerson() {
 
     @Relationship("favoriteArticle")
     var favoriteArticle: Article? = null

--- a/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorCustomPropertiesShould.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorCustomPropertiesShould.kt
@@ -1,0 +1,44 @@
+package com.undabot.izzy.parser
+
+import com.undabot.izzy.Given
+import com.undabot.izzy.Then
+import com.undabot.izzy.When
+import com.undabot.izzy.equals
+import com.undabot.izzy.jackson.JacksonParser
+import org.junit.Test
+
+class DeserializeErrorCustomPropertiesShould {
+
+    private val deserializeErrorCustomProperties = DeserializeErrorCustomProperties()
+    private lateinit var errorElement: JsonElements
+
+    private val idKey = "id"
+    private val statusKey = "status"
+    private val codeKey = "code"
+    private val titleKey = "title"
+    private val detailKey = "detail"
+    private val sourceKey = "source"
+    private val customKey = "customError"
+    private val customValue = "customErrorValue"
+    private val expectedErrorProperties =
+        listOf(idKey, statusKey, codeKey, titleKey, detailKey, sourceKey, META)
+    private val errorJson =
+        """{"customError":"customErrorValue","id":"12","status":"error","code":"code","title":"title","detail":"details"}"""
+
+    private var result: Map<String, Any?>? = null
+
+    @Test
+    fun `deserialize custom error properties but ignore expected`() {
+        Given { `json error element as`(errorJson) }
+        When {
+            result = deserializeErrorCustomProperties.from(errorElement, expectedErrorProperties)
+        }
+        Then {
+            result equals mapOf(customKey to customValue)
+        }
+    }
+
+    private fun `json error element as`(json: String) {
+        errorElement = JacksonParser().parseToJsonElements(json)
+    }
+}

--- a/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorShould.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorShould.kt
@@ -113,6 +113,13 @@ class DeserializeErrorShould {
         Then { actualError.meta equals hashMapOf("key" to "value") }
     }
 
+    @Test
+    fun `deserialize 'customProperties' from element to 'meta' in error`() {
+        Given { `json error element as`("""{"customError":{"key":"value"}}""") }
+        When { `deserialize is requested`() }
+        Then { actualError.customProperties equals hashMapOf("customError" to hashMapOf("key" to "value")) }
+    }
+
     private fun `json error element as`(json: String) {
         errorElement = JacksonParser().parseToJsonElements(json)
     }

--- a/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorsShould.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/parser/DeserializeErrorsShould.kt
@@ -42,7 +42,8 @@ class DeserializeErrorsShould {
             `json document as`("""{"errors":[
                                         {"detail":"error detail", "code":"3"},
                                         {"source":{"parameter":"parameter"},"title": "error title"},
-                                        {"meta":{"some_key":"some value"}, "status":"400"}
+                                        {"meta":{"some_key":"some value"}, "status":"400"},
+                                        {"custom_properties":{"custom_key":"some value"}}
                                     ]}""")
         }
         When { `deserialize is requested`() }
@@ -53,7 +54,8 @@ class DeserializeErrorsShould {
             arrayListOf(
                     Error(detail = "error detail", code = "3"),
                     Error(source = Source(parameter = "parameter"), title = "error title"),
-                    Error(meta = hashMapOf("some_key" to "some value"), status = "400"))
+                    Error(meta = hashMapOf("some_key" to "some value"), status = "400"),
+                    Error(customProperties = hashMapOf("custom_properties" to hashMapOf("custom_key" to "some value"))))
     )
 
     private fun `deserialize is requested`() {

--- a/parser/src/test/kotlin/com/undabot/izzy/parser/IzzyShould.kt
+++ b/parser/src/test/kotlin/com/undabot/izzy/parser/IzzyShould.kt
@@ -86,7 +86,10 @@ class IzzyShould {
         article2.author = person3
         article2.coauthors = arrayListOf(person1)
 
-        person1.favoriteArticle = article1
+        person1.apply {
+            favoriteArticle = article1
+            supervisor = person2
+        }
         person2.favoriteArticle = article1
         person3.favoriteArticle = article1
     }
@@ -101,6 +104,7 @@ class IzzyShould {
             result.data?.author equals person1
             result.data?.coauthors equals arrayListOf(person2, person3)
             result.data?.author?.favoriteArticle equals article1
+            result.data?.author?.supervisor equals person2
         }
     }
 
@@ -115,6 +119,8 @@ class IzzyShould {
             result.data!![1].author equals person1
             result.data!![0].author?.favoriteArticle equals article1
             result.data!![1].author?.favoriteArticle equals article1
+            result.data!![0].author?.supervisor equals null
+            result.data!![1].author?.supervisor equals person2
         }
     }
 

--- a/parser/src/test/resources/Article.json
+++ b/parser/src/test/resources/Article.json
@@ -49,7 +49,13 @@
                         "id":"1",
                         "type":"articles"
                      }
+                 },
+               "supervisor": {
+                 "data": {
+                   "id":"2",
+                   "type":"persons"
                  }
+               }
              }
         },
         {

--- a/parser/src/test/resources/Articles.json
+++ b/parser/src/test/resources/Articles.json
@@ -82,7 +82,13 @@
                         "id":"1",
                         "type":"articles"
                      }
+                 },
+               "supervisor": {
+                 "data": {
+                   "id":"2",
+                   "type":"persons"
                  }
+               }
              }
         },
         {

--- a/retrofit-converter/src/main/kotlin/com/undabot/izzy/retrofit/IzzyInvalidJsonResponseBodyConverter.kt
+++ b/retrofit-converter/src/main/kotlin/com/undabot/izzy/retrofit/IzzyInvalidJsonResponseBodyConverter.kt
@@ -1,0 +1,11 @@
+package com.undabot.izzy.retrofit
+
+import okhttp3.ResponseBody
+import retrofit2.Converter
+
+class IzzyInvalidJsonResponseBodyConverter : Converter<ResponseBody, Any?> {
+
+    override fun convert(value: ResponseBody): Any? {
+        return null
+    }
+}

--- a/retrofit-converter/src/test/kotlin/com/undabot/izzy/retrofit/IzzyRetrofitConverterShould.kt
+++ b/retrofit-converter/src/test/kotlin/com/undabot/izzy/retrofit/IzzyRetrofitConverterShould.kt
@@ -43,16 +43,19 @@ class IzzyRetrofitConverterShould {
         assert(converter.stringConverter(documentResourceType(), null, null) == null)
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `throw exception when response body converter is requested with unsupported type`() {
-        converter.responseBodyConverter(CustomObject::class.java, null, null)
+    @Test
+    fun `return invalid response body converter for invalid object`() {
+        val result = converter.responseBodyConverter(CustomObject::class.java, null, null)
+        assert(result is IzzyInvalidJsonResponseBodyConverter)
     }
 
     private fun resourceCollectionType(): Type = emptyList<Article>()::class.java.rawType
 
     private fun resourceType(): Type = Article::class.java.rawType
 
-    private fun documentCollectionType(): Type = object : TypeReference<JsonDocument<List<Article>>>() {}.type
+    private fun documentCollectionType(): Type =
+        object : TypeReference<JsonDocument<List<Article>>>() {}.type
 
-    private fun documentResourceType(): Type = object : TypeReference<JsonDocument<Article>>() {}.type
+    private fun documentResourceType(): Type =
+        object : TypeReference<JsonDocument<Article>>() {}.type
 }


### PR DESCRIPTION
This commit fixes issue related with gradle version 5.5.1 and running static analysis tools
when: `./gradlew detekt`
result:
`* What went wrong:
Cannot create service of type TaskExecuter using ProjectExecutionServices.createTaskExecuter() as there is a problem with parameter #21 of type ReservedFileSystemLocationRegistry.
> Cannot create service of type ReservedFileSystemLocationRegistry using ProjectExecutionServices.createReservedFileLocationRegistry() as there is a problem with parameter #1 of type List<ReservedFileSystemLocation>.
...`